### PR TITLE
alter_config() no longer accesses non-existing config files. Fixes #197.

### DIFF
--- a/run.py
+++ b/run.py
@@ -427,6 +427,11 @@ def do_counterparty_setup(run_as_user, backend_rpc_password, backend_rpc_passwor
         for net, backend_password, cp_password in (
             ('mainnet', backend_rpc_password, counterparty_rpc_password),
             ('testnet', backend_rpc_password_testnet, counterparty_rpc_password_testnet)):
+            # Check if the config was chosen to be replaced. Prevents accessing non-existing files.
+            if (questions.with_testnet == False and net == 'testnet') \
+               or (questions.with_mainnet == False and net == 'mainnet'):
+                continue
+
             #modify the default stored bitcoind passwords in counterparty conf
             modify_cp_config(r'^backend-password=.*?$', 'backend-password=%s' % backend_password,
                 config='counterparty', net=net)

--- a/run.py
+++ b/run.py
@@ -428,8 +428,8 @@ def do_counterparty_setup(run_as_user, backend_rpc_password, backend_rpc_passwor
             ('mainnet', backend_rpc_password, counterparty_rpc_password),
             ('testnet', backend_rpc_password_testnet, counterparty_rpc_password_testnet)):
             # Check if the config was chosen to be replaced. Prevents accessing non-existing files.
-            if (questions.with_testnet == False and net == 'testnet') \
-               or (questions.with_mainnet == False and net == 'mainnet'):
+            if (net == 'testnet' and not questions.with_testnet) \
+               or (net == 'mainnet' and not questions.with_mainnet):
                 continue
 
             #modify the default stored bitcoind passwords in counterparty conf


### PR DESCRIPTION
The problem only shows if you install mainnet only and then try to rebuild (since installing testnet installs mainnet config file anyway). The function tries to replace config data in non-existing server.testnet.conf.